### PR TITLE
Fix duplication in assistant messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -415,9 +415,6 @@ class ChatGPT:
             self.messages.append(assistant_message)
             self.append_to_log(token_usage=token_usage, new_message=assistant_message)
 
-            # 附加聊天记录
-            self.messages.append({"role": "assistant", "content": content})
-
             return content, token_usage
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- remove duplicate assistant message added to conversation history in `main.py`

## Testing
- `python -m py_compile main.py utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684133b03dac832d8ee926bff6a99237